### PR TITLE
Fix dead link created by Ampache/ampache:b939e5e

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -117,7 +117,7 @@
 				<div class="align"> <i class="icon-desktop sev_icon"></i> </div>
 				<h2>Translation</h2>
 				<p>Ampache is translated to several languages. You can improve current translation or even add new ones!</p>
-				<a href="https://github.com/ampache/ampache/blob/master/locale/base/TRANSLATIONS" class="more-link">read more</a>
+				<a href="https://github.com/ampache/ampache/blob/master/locale/base/TRANSLATIONS.md" class="more-link">read more</a>
 			</div>
 			<div class="span4">
 				<div class="align"> <i class="icon-desktop sev_icon"></i> </div>


### PR DESCRIPTION
Or maybe we could consider moving this page to the Wiki?
https://github.com/ampache/ampache/wiki/Translations
